### PR TITLE
Change API for Hyper with Electron v1.6.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Touch bar plugin starter for [Hyper](https://github.com/zeit/hyper)
 2. Add `hyper-touch` to `~/.hyper.js`'s localPlugins array.
 3. Launch Hyper and this should show a button in the touch bar.
 
-## Please note:
+## Please note
 
 The current version of [Hyper](https://github.com/zeit/hyper) (v1.3.1)
 is not delivered with the [Electron](https://github.com/electron/electron) beta

--- a/README.md
+++ b/README.md
@@ -1,7 +1,15 @@
 # hyper-touch
-Touch bar plugin starter for hyper
+
+Touch bar plugin starter for [Hyper](https://github.com/zeit/hyper)
 
 ## Installation
-1. Clone into `~/.hyper_plugins/local/`
-2. Add 'hyper-touch' to `~/.hyper.js`'s localPlugins array.
-3. Launch hyper and this should show a button in the touch bar with the 'click me' label that logs 'clicked'.
+
+1. Clone this repository into `~/.hyper_plugins/local/`
+2. Add `hyper-touch` to `~/.hyper.js`'s localPlugins array.
+3. Launch Hyper and this should show a button in the touch bar.
+
+## Please note:
+
+The current version of [Hyper](https://github.com/zeit/hyper) (v1.3.1)
+is not delivered with the [Electron](https://github.com/electron/electron) beta
+(v1.6.3). Touch bar support is available as of version 1.6.3 of Electron.

--- a/index.js
+++ b/index.js
@@ -1,15 +1,13 @@
-const { TouchBar } = require('electron');
+const { TouchBar } = require('electron').remote;
 const { TouchBarButton } = TouchBar;
 
-if (TouchBar) {
-	const buttons = [new TouchBarButton({
-		label: `Click me`.toUpperCase(),
-		click: () => {
-			console.log('clicked')
-		}
-	})]
-
-	exports.onWindow = (win) => {
-		win.setTouchBar(new TouchBar(buttons));
+const button = new TouchBarButton({
+	label: `🦄 Click me`,
+	click: () => {
+		console.log('TouchBarButton was clicked');
 	}
+});
+
+exports.onWindow = (win) => {
+	win.setTouchBar(new TouchBar([button]));
 }


### PR DESCRIPTION
**Changes**

* Use main process modules from the renderer process.

  > The `remote` module provides a simple way to do inter-process communication
(IPC) between the renderer process (web page) and the main process.
  >
  > In Electron, GUI-related modules (such as `dialog`, `menu` etc.) are only
available in the main process, not in the renderer process.

  See https://github.com/electron/electron/blob/master/docs/api/remote.md

* Add `Please note` section to README
